### PR TITLE
Use rails_helper instead of spec_helper

### DIFF
--- a/lib/generators/templates/spec.erb
+++ b/lib/generators/templates/spec.erb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe <%= class_name %>, type: :actor do
   describe '.call' do

--- a/spec/service_actor/rails_spec.rb
+++ b/spec/service_actor/rails_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe ServiceActor::Rails do
       <<~SPEC_FILE
         # frozen_string_literal: true
 
-        require 'spec_helper'
+        require 'rails_helper'
 
         RSpec.describe PayOrder, type: :actor do
           describe '.call' do
@@ -110,7 +110,7 @@ RSpec.describe ServiceActor::Rails do
         <<~SPEC_FILE
           # frozen_string_literal: true
 
-          require 'spec_helper'
+          require 'rails_helper'
 
           RSpec.describe Orders::Pay, type: :actor do
             describe '.call' do


### PR DESCRIPTION
This will fix `NameError` when run rspec with generated rspec file.
Also this can be close #2.